### PR TITLE
Add vcs-browser tag

### DIFF
--- a/org.apache.netbeans.metainfo.xml
+++ b/org.apache.netbeans.metainfo.xml
@@ -596,5 +596,6 @@ Error Notifications
   <url type="bugtracker">https://netbeans.apache.org/participate/report-issue.html</url>
   <url type="donation">https://netbeans.apache.org/participate/index.html</url>
   <url type="help">https://netbeans.apache.org/help/index.html</url>
+  <url type="vcs-browser">https://github.com/apache/netbeans</url>
 
 </component>


### PR DESCRIPTION
There is a  linter warnings "appstream-missing-vcs-browser-url' warning found in linter repo check. Details: Please consider adding a vcs-browser URL to the Metainfo file" 